### PR TITLE
Fix issue when updating post if product_cat was unregistered

### DIFF
--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -94,7 +94,7 @@ class SKU_Shortlink_For_WooCommerce_Frontend {
         $postname = $post->post_name;
         $category = wp_get_post_terms($id, 'product_cat');
         
-        if(!empty($category)){
+        if(!empty($category) && !is_wp_error($category)){
             $category = $category[0]->slug;    
         } else {
             $category = '';


### PR DESCRIPTION
I have this code in my theme to unregister Product Categories because they won't be used on this custom site.
```
add_action( 'init', function () {
    unregister_taxonomy( 'product_cat' );
} );
```
However because the taxonomy is no longer registered, the function `wp_get_post_terms` returns a WP_Error with a message that the taxonomy doesn't exist. Checking to see if the categories result is not a wp error should fix this problem.